### PR TITLE
Hide consultations block when editing consultation

### DIFF
--- a/app/templates/entry.html
+++ b/app/templates/entry.html
@@ -56,6 +56,7 @@
 {% for section in sections %}
 {% include 'section.html' %}
 {% endfor %}
+{% if table == 'patient' %}
 <div class="container-fluid">
     <div class="d-flex justify-content-between">
         <div class="p-2">
@@ -100,6 +101,7 @@
         {% endfor %}
     </tbody>
 </table>
+{% endif %}
 
 <script>
     let currentDate = new Date();


### PR DESCRIPTION
## Summary
- display the consultations list only when editing a patient entry so it stays hidden while editing a consultation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eb4a64b43083299828fd01d3b5d9c4