### PR TITLE
Allow editing consultation location with a default value

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -69,9 +69,9 @@ def create_blueprint_for_model(model_class):
                 if hasattr(payload['data'], key):
                     setattr(payload['data'], key, form_data[key])
             db.session.commit()
-            
+
             return redirect(url_for(f"{model_class.__tablename__}.all"))
-        
+
         # Create a new entry if the form is submitted.
         elif not id and request.method == 'POST':
             new_entry = model_class(**form_data)
@@ -80,6 +80,10 @@ def create_blueprint_for_model(model_class):
             return redirect(url_for(f"{payload['table']}.update") + "/" + repr(new_entry.id))
         else:
             # Generate the form fields.
+            if not id and model_class.__tablename__ == 'consultation':
+                location = utils.determine_consultation_location()
+                if location and hasattr(payload['data'], 'location'):
+                    setattr(payload['data'], 'location', getattr(payload['data'], 'location') or location)
             payload['rows'] = utils.generate_rows(model_class, payload)
             payload['sections'] = utils.build_sections(model_class.__tablename__, payload, current_user)
             if hasattr(payload['data'], 'date') and payload['data'].date == datetime.now().date():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import importlib.util
 import os
 import sys
 import types
-from datetime import date
+from datetime import date, datetime
 
 # Ensure the application package is on the path
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -60,3 +60,17 @@ def test_append_select_3_builds_html():
     assert 'id="drugstore-search"' in html
     assert 'name="drugstore"' in html
     assert 'id="drugstore-table"' in html
+
+
+def test_determine_consultation_location():
+    monday_morning = datetime(2023, 4, 3, 9, 0)
+    tuesday_afternoon = datetime(2023, 4, 4, 15, 30)
+    thursday_morning = datetime(2023, 4, 6, 10, 0)
+    thursday_afternoon = datetime(2023, 4, 6, 13, 0)
+    sunday = datetime(2023, 4, 2, 10, 0)
+
+    assert utils.determine_consultation_location(monday_morning) == 'IPS'
+    assert utils.determine_consultation_location(tuesday_afternoon) == 'ES'
+    assert utils.determine_consultation_location(thursday_morning) == 'Elancourt'
+    assert utils.determine_consultation_location(thursday_afternoon) == 'IPS'
+    assert utils.determine_consultation_location(sunday) is None


### PR DESCRIPTION
## Summary
- keep consultation locations editable while still capturing form updates
- pre-fill new consultation forms with the automatically determined location
- render the consultation location field as an editable input again

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690993611808832990b14a96c454c1cc