### PR TITLE
Add admin stats CSV export page

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -1,12 +1,17 @@
 # admin.py
 
 from datetime import datetime
-from io import BytesIO
+from io import BytesIO, StringIO
+from pathlib import Path
+import csv
+import re
+import unicodedata
 
-from flask import Blueprint, abort, send_file
+from flask import Blueprint, Response, abort, current_app, render_template, send_file
 from flask_login import current_user, login_required
 from openpyxl import Workbook
-from sqlalchemy import select
+from sqlalchemy import select, text
+import yaml
 
 from . import db
 from .roles import Role
@@ -23,6 +28,71 @@ def is_sensitive_column(column_name):
     normalized = column_name.lower()
     if normalized in SENSITIVE_COLUMNS:
         return True
+
+
+def _slugify(value):
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_value = normalized.encode("ascii", "ignore").decode("ascii")
+    slug = re.sub(r"[^A-Za-z0-9_-]+", "-", ascii_value).strip("-").lower()
+    return slug or "export"
+
+
+def _load_datasette_queries():
+    datasette_path = Path(current_app.root_path).parent / "datasette.yml"
+    if not datasette_path.exists():
+        return {}
+
+    datasette_config = yaml.safe_load(datasette_path.read_text(encoding="utf-8")) or {}
+    databases = datasette_config.get("databases", {})
+    database_config = databases.get("gestebenevole")
+    if not database_config and databases:
+        database_config = next(iter(databases.values()))
+
+    queries = (database_config or {}).get("queries", {})
+    return {
+        name: {"sql": details.get("sql", "").strip(), "hide_sql": details.get("hide_sql", False)}
+        for name, details in queries.items()
+    }
+
+
+@admin.route("/stats", methods=["GET"])
+@login_required
+def stats():
+    if not current_user.has_role(Role.ADMIN):
+        return abort(403)
+
+    queries = _load_datasette_queries()
+    return render_template(
+        "admin_stats.html",
+        user=current_user,
+        queries=[{"name": name, **details} for name, details in queries.items()],
+    )
+
+
+@admin.route("/stats/<path:query_name>/csv", methods=["GET"])
+@login_required
+def export_stats_query(query_name):
+    if not current_user.has_role(Role.ADMIN):
+        return abort(403)
+
+    queries = _load_datasette_queries()
+    query = queries.get(query_name)
+    if not query or not query["sql"]:
+        return abort(404)
+
+    result = db.session.execute(text(query["sql"]))
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow(result.keys())
+    for row in result:
+        writer.writerow(list(row))
+
+    filename = f"{_slugify(query_name)}.csv"
+    return Response(
+        output.getvalue(),
+        mimetype="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @admin.route("/export", methods=["GET"])

--- a/app/templates/admin_stats.html
+++ b/app/templates/admin_stats.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="h3 mb-0">Statistiques</h1>
+    <a class="btn btn-outline-secondary" href="{{ url_for('admin.export_database') }}">
+      Télécharger la base complète
+    </a>
+  </div>
+
+  {% if queries %}
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Requête</th>
+          <th>Export CSV</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for query in queries %}
+        <tr>
+          <td>{{ query.name }}</td>
+          <td>
+            {% if query.sql %}
+            <a class="btn btn-sm btn-primary" href="{{ url_for('admin.export_stats_query', query_name=query.name) }}">
+              Télécharger
+            </a>
+            {% else %}
+            <span class="text-muted">Indisponible</span>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+  <p class="text-muted">Aucune requête disponible.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -58,6 +58,11 @@
           <a class="nav-link" href="{{ url_for('user.all') }}">Utilisateurs</a>
         </li>
         {% endif %}
+        {% if user.has_role(1) %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('admin.stats') }}">Stats</a>
+        </li>
+        {% endif %}
         {% if user.can_read('patient') %}
         <li class="nav-item {% if table == 'patient' %}active{% endif %}">
           <a class="nav-link" href="{{ url_for('patient.all') }}">Patients</a>

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ gunicorn>=20.1.0
 python-dateutil>=2.8.2
 weasyprint>=59.3
 openpyxl>=3.1.2
+PyYAML>=6.0.1


### PR DESCRIPTION
### Motivation
- Provide an admin-only UI to reuse the SQL queries declared in `datasette.yml` and let admins download each query result as CSV.  
- Make it easy to download the full database export from the same admin area.

### Description
- Added a new admin page at `GET /admin/stats` that reads queries from `datasette.yml` and lists them with CSV download links by name.  
- Implemented `GET /admin/stats/<query_name>/csv` which executes the query and streams a CSV download using a safe slugified filename.  
- Implemented YAML parsing of `datasette.yml` (loaded from the project root), a `_slugify` helper for filenames, and query loading logic in `app/admin.py`, and kept all routes protected to `Role.ADMIN`.  
- Added the `app/templates/admin_stats.html` template and added `PyYAML>=6.0.1` to `requirements.txt` for parsing the datasette config.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697494365d188329b3eefadfd40bf063)